### PR TITLE
Initialize application with dependency injection

### DIFF
--- a/src/main/java/com/db/signaltrade/Application.java
+++ b/src/main/java/com/db/signaltrade/Application.java
@@ -2,7 +2,6 @@ package com.db.signaltrade;
 
 import com.db.signaltrade.action.SignalAction;
 import com.db.signaltrade.action.SignalActionFactory;
-import com.db.signaltrade.action.SignalActionFactoryImpl;
 import com.othercompany.lib.Algo;
 import com.othercompany.lib.SignalHandler;
 
@@ -10,10 +9,15 @@ import com.othercompany.lib.SignalHandler;
  * This is your team’s code and should be changed as you see fit.
  */
 class Application implements SignalHandler {
-    private final SignalActionFactory signalActionFactory = new SignalActionFactoryImpl();
+    private final SignalActionFactory signalActionFactory;
+    private final Algo algo;
+
+    Application(SignalActionFactory signalActionFactory, Algo algo) {
+        this.signalActionFactory = signalActionFactory;
+        this.algo = algo;
+    }
 
     public void handleSignal(int signal) {
-        Algo algo = new Algo();
         SignalAction action = signalActionFactory.create(signal);
         action.perform(algo);
         algo.doAlgo();

--- a/src/main/java/com/db/signaltrade/ApplicationTest.java
+++ b/src/main/java/com/db/signaltrade/ApplicationTest.java
@@ -1,9 +1,6 @@
 package com.db.signaltrade;
 
-import com.db.signaltrade.action.DefaultSignalAction;
-import com.db.signaltrade.action.SignalAction;
-import com.db.signaltrade.action.SignalActionFactory;
-import com.db.signaltrade.action.SignalActionFactoryImpl;
+import com.db.signaltrade.action.*;
 import com.othercompany.lib.Algo;
 import com.othercompany.lib.SignalHandler;
 import org.junit.jupiter.api.Test;
@@ -55,7 +52,7 @@ class ApplicationTest {
     // Test covers only signals from the legacy application.
     @Test
     void testCompareWithLegacy() {
-        SignalHandler application = new Application();
+        SignalHandler application = new Application(signalActionFactory, new Algo());
         SignalHandler legacyApplication = new LegacyApplication();
 
         // initialize two buffers that will read the output of both applications


### PR DESCRIPTION
- Use dependency injection of SignalActionFactory and Algo instead of later initialization in the class to have more control over passed interfaces (e.g. to switch factory or algo on startup)
- Adjust the according tests